### PR TITLE
Add conversation memory for multi-turn questions

### DIFF
--- a/agents/qa_agent.py
+++ b/agents/qa_agent.py
@@ -107,21 +107,27 @@ class QAAgent:
         model: str = "claude-sonnet-4-6",
         top_k: int = 5,
         demo_mode: bool = False,
+        max_history_turns: int = 10,
     ):
         """
         Initialize the QA agent.
 
         Args:
-            vector_store: The VectorStore containing document chunks
-            api_key:      Anthropic API key (reads from env if None)
-            model:        LLM model to use for answers
-            top_k:        How many chunks to retrieve per question
-            demo_mode:    If True, skip API calls and return raw context
+            vector_store:      The VectorStore containing document chunks
+            api_key:           Anthropic API key (reads from env if None)
+            model:             LLM model to use for answers
+            top_k:             How many chunks to retrieve per question
+            demo_mode:         If True, skip API calls and return raw context
+            max_history_turns: Maximum past user/assistant pairs to forward
+                               with each question. Older turns are dropped
+                               (oldest-first) so the context window stays
+                               bounded.
         """
         self.demo_mode = demo_mode
         self.model = model
         self.vector_store = vector_store
         self.top_k = top_k
+        self.max_history_turns = max_history_turns
 
         # Only create the API client if we actually need it
         if not demo_mode:
@@ -129,7 +135,11 @@ class QAAgent:
         else:
             self.client = None
 
-    def ask(self, question: str) -> QAResponse:
+    def ask(
+        self,
+        question: str,
+        conversation_history: list[dict] | None = None,
+    ) -> QAResponse:
         """
         Ask a question about the loaded documents.
 
@@ -140,7 +150,13 @@ class QAAgent:
           4. Return the answer with source references
 
         Args:
-            question: The user's question in natural language
+            question:             The user's question in natural language
+            conversation_history: Previous turns as a list of
+                                  ``{"role": "user"|"assistant",
+                                  "content": str}`` dicts. Trimmed to the
+                                  last ``max_history_turns`` exchanges
+                                  before being sent to the model. Demo
+                                  mode ignores it.
 
         Returns:
             QAResponse with the answer and source references
@@ -163,7 +179,7 @@ class QAAgent:
             # Demo mode: show the retrieved chunks directly
             answer_text = self._build_demo_answer(question, search_results)
         else:
-            # Normal mode: send to LLM API
+            # Normal mode: send to LLM API with optional conversation history
             user_message = (
                 f"Context from the user's documents:\n"
                 f"---\n"
@@ -172,11 +188,13 @@ class QAAgent:
                 f"Question: {question}"
             )
 
+            messages = self._build_messages(conversation_history, user_message)
+
             response = self.client.messages.create(
                 model=self.model,
                 max_tokens=2048,
                 system=SYSTEM_PROMPT,
-                messages=[{"role": "user", "content": user_message}],
+                messages=messages,
             )
 
             answer_text = response.content[0].text
@@ -196,6 +214,33 @@ class QAAgent:
             sources=sources,
             model="demo-mode" if self.demo_mode else self.model,
         )
+
+    def _build_messages(
+        self,
+        conversation_history: list[dict] | None,
+        latest_user_message: str,
+    ) -> list[dict]:
+        """Combine trimmed conversation history with the current turn.
+
+        Filters out anything that isn't a clean user/assistant pair and
+        keeps only the most recent ``max_history_turns`` exchanges so the
+        token budget stays predictable.
+        """
+        messages: list[dict] = []
+
+        if conversation_history:
+            cleaned = [
+                {"role": m["role"], "content": m["content"]}
+                for m in conversation_history
+                if isinstance(m, dict)
+                and m.get("role") in ("user", "assistant")
+                and isinstance(m.get("content"), str)
+            ]
+            # Keep the last 2*max_history_turns messages (a turn = user + assistant)
+            messages.extend(cleaned[-self.max_history_turns * 2:])
+
+        messages.append({"role": "user", "content": latest_user_message})
+        return messages
 
     def _build_demo_answer(self, question: str, results: list[SearchResult]) -> str:
         """

--- a/app.py
+++ b/app.py
@@ -234,7 +234,14 @@ if prompt := st.chat_input("Ask a question about your documents..."):
                 api_key=api_key if not demo_mode else None,
                 demo_mode=demo_mode,
             )
-            response = agent.ask(prompt)
+            # Forward the chat history (excluding the new user message we
+            # just appended) so the model can resolve follow-up questions.
+            history = [
+                {"role": m["role"], "content": m["content"]}
+                for m in st.session_state.messages[:-1]
+                if m.get("role") in ("user", "assistant")
+            ]
+            response = agent.ask(prompt, conversation_history=history)
 
         st.markdown(response.answer)
 

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -145,6 +145,102 @@ class TestQAAgent:
         assert "Source:" in context
 
 
+# --- Conversation memory ---
+
+class TestConversationHistory:
+    """ask() must forward previous turns to the LLM and cap history length."""
+
+    @patch("agents.qa_agent.anthropic.Anthropic")
+    def test_no_history_sends_single_user_message(
+        self, mock_client_class, mock_store, mock_anthropic_response
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.messages.create.return_value = mock_anthropic_response
+
+        agent = QAAgent(vector_store=mock_store, api_key="test-key")
+        agent.ask("Who is the CEO?")
+
+        messages = mock_client.messages.create.call_args.kwargs["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    @patch("agents.qa_agent.anthropic.Anthropic")
+    def test_history_is_forwarded(
+        self, mock_client_class, mock_store, mock_anthropic_response
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.messages.create.return_value = mock_anthropic_response
+
+        agent = QAAgent(vector_store=mock_store, api_key="test-key")
+        history = [
+            {"role": "user", "content": "What is the revenue?"},
+            {"role": "assistant", "content": "EUR 47.3 million."},
+        ]
+        agent.ask("And the year before?", conversation_history=history)
+
+        messages = mock_client.messages.create.call_args.kwargs["messages"]
+        assert len(messages) == 3
+        assert messages[0] == {"role": "user", "content": "What is the revenue?"}
+        assert messages[1] == {"role": "assistant", "content": "EUR 47.3 million."}
+        assert messages[2]["role"] == "user"
+        assert "year before" in messages[2]["content"]
+
+    @patch("agents.qa_agent.anthropic.Anthropic")
+    def test_history_is_trimmed_to_max_turns(
+        self, mock_client_class, mock_store, mock_anthropic_response
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.messages.create.return_value = mock_anthropic_response
+
+        # 6 full turns = 12 messages; max=2 turns should keep the last 4
+        history = []
+        for i in range(6):
+            history.append({"role": "user", "content": f"q{i}"})
+            history.append({"role": "assistant", "content": f"a{i}"})
+
+        agent = QAAgent(vector_store=mock_store, api_key="test-key", max_history_turns=2)
+        agent.ask("latest?", conversation_history=history)
+
+        messages = mock_client.messages.create.call_args.kwargs["messages"]
+        # 2 turns * 2 messages + 1 new user = 5
+        assert len(messages) == 5
+        assert messages[0] == {"role": "user", "content": "q4"}
+        assert messages[1] == {"role": "assistant", "content": "a4"}
+        assert messages[-1]["role"] == "user"
+        assert "latest" in messages[-1]["content"]
+
+    @patch("agents.qa_agent.anthropic.Anthropic")
+    def test_history_filters_unexpected_roles(
+        self, mock_client_class, mock_store, mock_anthropic_response
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.messages.create.return_value = mock_anthropic_response
+
+        history = [
+            {"role": "user", "content": "ok"},
+            {"role": "system", "content": "ignored"},        # should be dropped
+            {"role": "assistant", "content": "ok back"},
+            {"role": "user"},                                  # missing content
+            {"foo": "bar"},                                    # not a turn
+        ]
+        agent = QAAgent(vector_store=mock_store, api_key="test-key")
+        agent.ask("next?", conversation_history=history)
+
+        messages = mock_client.messages.create.call_args.kwargs["messages"]
+        assert [m["role"] for m in messages] == ["user", "assistant", "user"]
+
+    def test_demo_mode_ignores_history(self, mock_store):
+        agent = QAAgent(vector_store=mock_store, demo_mode=True)
+        history = [{"role": "user", "content": "earlier"},
+                   {"role": "assistant", "content": "answer"}]
+
+        # Should not raise even though no API client exists, and should
+        # still produce a demo-mode answer with the retrieved chunks.
+        response = agent.ask("revenue?", conversation_history=history)
+        assert response.model == "demo-mode"
+        assert "DEMO MODE" in response.answer
+
+
 # --- System prompt ---
 
 class TestSystemPrompt:


### PR DESCRIPTION
## Summary

- `QAAgent.ask` now takes an optional `conversation_history` of `{"role": "user"|"assistant", "content": str}` dicts
- History is filtered (drops invalid roles / missing content), trimmed to the last `max_history_turns` exchanges (default 10), and prepended to the Anthropic `messages` array
- Streamlit forwards `st.session_state.messages` (minus the new turn) so follow-ups like *"and the year before?"* resolve against prior context
- Demo mode is unchanged, accepts the parameter but ignores it
- 5 new tests bring the suite from 65 to 70

Closes #13

## Test plan

- [x] All 70 backend tests pass (`pytest -q`)
- [x] Existing single-turn flow unchanged (one user message in API call when no history)
- [ ] Manual: ask "What was revenue?" then "and the year before?": the second answer references the first
