### PR TITLE
Harden ChromaDB client creation under Streamlit

### DIFF
--- a/agents/vectorstore.py
+++ b/agents/vectorstore.py
@@ -25,6 +25,7 @@ ChromaDB handles the embedding automatically using a built-in model
 """
 
 import chromadb
+from chromadb.config import Settings
 from pydantic import BaseModel, Field
 
 from .chunker import TextChunk
@@ -80,10 +81,13 @@ class VectorStore:
             persist_dir: Directory to save the database (None = in-memory only)
             collection_name: Name for the ChromaDB collection
         """
+        # Disable anonymized telemetry: its background thread has been
+        # implicated in chromadb client-teardown races on Streamlit Cloud.
+        settings = Settings(anonymized_telemetry=False)
         if persist_dir:
-            self._client = chromadb.PersistentClient(path=persist_dir)
+            self._client = chromadb.PersistentClient(path=persist_dir, settings=settings)
         else:
-            self._client = chromadb.EphemeralClient()
+            self._client = chromadb.EphemeralClient(settings=settings)
 
         # get_or_create: if the collection exists, reuse it; otherwise create it
         self._collection = self._client.get_or_create_collection(

--- a/app.py
+++ b/app.py
@@ -54,11 +54,23 @@ st.set_page_config(
 # ---------------------------------------------------------------------------
 
 
+@st.cache_resource
+def get_vector_store(persist_dir: str) -> VectorStore:
+    """Create the ChromaDB-backed store once and reuse it across sessions.
+
+    Streamlit runs many sessions in a single process, and chromadb keeps a
+    process-global registry of clients, so building a new client per session
+    can race on that registry. Caching the store as a shared resource creates
+    the client exactly once.
+    """
+    return VectorStore(persist_dir=persist_dir)
+
+
 def init_session_state():
     """Initialize session state variables if they don't exist yet."""
     if "vector_store" not in st.session_state:
         persist_dir = os.environ.get("CHROMA_PERSIST_DIR", DEFAULT_PERSIST_DIR)
-        st.session_state.vector_store = VectorStore(persist_dir=persist_dir)
+        st.session_state.vector_store = get_vector_store(persist_dir)
     if "messages" not in st.session_state:
         st.session_state.messages = []
     if "uploaded_files" not in st.session_state:


### PR DESCRIPTION
## Background
The live demo hit a `KeyError` at startup in ChromaDB's process-global client registry (`shared_system_client.py:_create_system_if_not_exists`). A reboot cleared it, but the underlying fragility remains: the store was created per session, so concurrent Streamlit sessions could race on that shared registry.

## Change
- Create the vector store once via `@st.cache_resource` instead of per session, so the ChromaDB client is built exactly once and reused.
- Disable anonymized telemetry (`Settings(anonymized_telemetry=False)`), whose background thread is commonly implicated in these client-teardown races on Streamlit Cloud.

No behavior change for users (the persistent store was already shared across sessions). Full suite: 70 passed.