### PR TITLE
Revert ChromaDB Streamlit hardening (caused a settings-mismatch error)

### DIFF
--- a/agents/vectorstore.py
+++ b/agents/vectorstore.py
@@ -25,7 +25,6 @@ ChromaDB handles the embedding automatically using a built-in model
 """
 
 import chromadb
-from chromadb.config import Settings
 from pydantic import BaseModel, Field
 
 from .chunker import TextChunk
@@ -81,13 +80,10 @@ class VectorStore:
             persist_dir: Directory to save the database (None = in-memory only)
             collection_name: Name for the ChromaDB collection
         """
-        # Disable anonymized telemetry: its background thread has been
-        # implicated in chromadb client-teardown races on Streamlit Cloud.
-        settings = Settings(anonymized_telemetry=False)
         if persist_dir:
-            self._client = chromadb.PersistentClient(path=persist_dir, settings=settings)
+            self._client = chromadb.PersistentClient(path=persist_dir)
         else:
-            self._client = chromadb.EphemeralClient(settings=settings)
+            self._client = chromadb.EphemeralClient()
 
         # get_or_create: if the collection exists, reuse it; otherwise create it
         self._collection = self._client.get_or_create_collection(

--- a/app.py
+++ b/app.py
@@ -54,23 +54,11 @@ st.set_page_config(
 # ---------------------------------------------------------------------------
 
 
-@st.cache_resource
-def get_vector_store(persist_dir: str) -> VectorStore:
-    """Create the ChromaDB-backed store once and reuse it across sessions.
-
-    Streamlit runs many sessions in a single process, and chromadb keeps a
-    process-global registry of clients, so building a new client per session
-    can race on that registry. Caching the store as a shared resource creates
-    the client exactly once.
-    """
-    return VectorStore(persist_dir=persist_dir)
-
-
 def init_session_state():
     """Initialize session state variables if they don't exist yet."""
     if "vector_store" not in st.session_state:
         persist_dir = os.environ.get("CHROMA_PERSIST_DIR", DEFAULT_PERSIST_DIR)
-        st.session_state.vector_store = get_vector_store(persist_dir)
+        st.session_state.vector_store = VectorStore(persist_dir=persist_dir)
     if "messages" not in st.session_state:
         st.session_state.messages = []
     if "uploaded_files" not in st.session_state:


### PR DESCRIPTION
Reverts #35.

The hardening backfired: passing an explicit `Settings(anonymized_telemetry=False)` to `PersistentClient` collides with ChromaDB's default-settings client for the same persist path, raising `ValueError: An instance of Chroma already exists ... with different settings` deterministically on every load (reproduced locally: explicit settings + default settings for the same path conflict).

Reverting restores the known-working code. The original transient KeyError (if it recurs after a redeploy) is cleared by a one-off app reboot. A proper hardening needs an environment where the Streamlit-Cloud-specific behavior can be reproduced, which we do not have.